### PR TITLE
Add queue helpers to QueueContext

### DIFF
--- a/Sources/Queues/QueueContext.swift
+++ b/Sources/Queues/QueueContext.swift
@@ -37,4 +37,19 @@ public struct QueueContext {
         self.logger = logger
         self.eventLoop = eventLoop
     }
+
+    /// The `JobsQueue` object
+    public var queue: Queue {
+        self.queues(.default)
+    }
+
+    /// A jobs queue for a specific queue name
+    /// - Parameter queue: The queue name
+    public func queues(_ queue: QueueName) -> Queue {
+        self.application.queues.queue(
+            queue,
+            logger: self.logger,
+            on: self.eventLoop
+        )
+    }
 }

--- a/Sources/Queues/QueueContext.swift
+++ b/Sources/Queues/QueueContext.swift
@@ -38,12 +38,12 @@ public struct QueueContext {
         self.eventLoop = eventLoop
     }
 
-    /// The `JobsQueue` object
+    /// Returns the default job `Queue`
     public var queue: Queue {
         self.queues(.default)
     }
 
-    /// A jobs queue for a specific queue name
+    /// Returns the specific job `Queue` for the given queue name
     /// - Parameter queue: The queue name
     public func queues(_ queue: QueueName) -> Queue {
         self.application.queues.queue(

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -31,7 +31,7 @@ public struct QueueWorker {
                     return self.queue.eventLoop.makeSucceededFuture(())
                 }
 
-                self.queue.logger.info("Dequeing Job: ", metadata: [
+                self.queue.logger.info("Dequeing job", metadata: [
                     "job_id": .string(id.string),
                     "job_name": .string(data.jobName)
                 ])

--- a/Sources/Queues/Request+Queues.swift
+++ b/Sources/Queues/Request+Queues.swift
@@ -7,7 +7,7 @@ extension Request {
     public var queue: Queue {
         self.queues(.default)
     }
-    
+
     /// A jobs queue for a specific queue name
     /// - Parameter queue: The queue name
     public func queues(_ queue: QueueName) -> Queue {

--- a/Sources/Queues/Request+Queues.swift
+++ b/Sources/Queues/Request+Queues.swift
@@ -3,12 +3,12 @@ import Vapor
 import NIO
 
 extension Request {
-    /// The `JobsQueue` object
+    /// Returns the default job `Queue`
     public var queue: Queue {
         self.queues(.default)
     }
 
-    /// A jobs queue for a specific queue name
+    /// Returns the specific job `Queue` for the given queue name
     /// - Parameter queue: The queue name
     public func queues(_ queue: QueueName) -> Queue {
         self.application.queues.queue(


### PR DESCRIPTION
Add `queue` and `queues(_:)` helpers to `QueueContext` so that jobs may also be dispatched from other jobs, just like they are currently dispatched from a `Request` (#71).