### PR TITLE
Print log if scheduled job fails

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,5 @@
 /*.xcodeproj
 DerivedData
 Package.resolved
-
 .swiftpm
+Tests/LinuxMain.swift

--- a/Sources/Queues/QueuesCommand.swift
+++ b/Sources/Queues/QueuesCommand.swift
@@ -133,7 +133,12 @@ public final class QueuesCommand: Command {
         
         if let task = job.schedule(context: context) {
             self.scheduledTasks[job.job.name] = task
-            task.done.whenComplete { _ in
+            task.done.whenComplete { result in
+                switch result {
+                case .failure(let error):
+                    context.logger.error("\(job.job.name) failed: \(error)")
+                case .success: break
+                }
                 self.schedule(job)
             }
         }


### PR DESCRIPTION
A log message will now be printed if any `ScheduledJob` returns a failure (#82).