### PR TITLE
Logging metadata improvements

### DIFF
--- a/Sources/Queues/Queue.swift
+++ b/Sources/Queues/Queue.swift
@@ -83,7 +83,7 @@ extension Queue {
             self.push(id)
         }.map { _ in
             self.logger.info("Dispatched queue job", metadata: [
-                "job_id": .string("\(id)"),
+                "job_id": .string(id.string),
                 "job_name": .string(job.name),
                 "queue": .string(self.queueName.string)
             ])

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -33,7 +33,8 @@ public struct QueueWorker {
 
                 self.queue.logger.info("Dequeing job", metadata: [
                     "job_id": .string(id.string),
-                    "job_name": .string(data.jobName)
+                    "job_name": .string(data.jobName),
+                    "queue": .string(self.queue.queueName.string)
                 ])
                 var logger = self.queue.logger
                 logger[metadataKey: "job_id"] = .string(id.string)

--- a/Sources/Queues/QueuesCommand.swift
+++ b/Sources/Queues/QueuesCommand.swift
@@ -77,7 +77,7 @@ public final class QueuesCommand: Command {
         } else {
             let queue: QueueName = signature.queue
                 .flatMap { .init(string: $0) } ?? .default
-            self.application.logger.info("Starting jobs worker (queue: \(queue.string))")
+            self.application.logger.info("Starting jobs worker", metadata: ["queue": .string(queue.string)])
             try self.startJobs(on: queue)
         }
     }


### PR DESCRIPTION
(#83)
* Log the job ID rather than the whole struct when a job is dispatched
* Log the queue name when a job is dequeued
* Move queue name into metadata for worker starting notice