### PR TITLE
Allow worker count to be configured

### DIFF
--- a/Sources/Queues/QueuesConfiguration.swift
+++ b/Sources/Queues/QueuesConfiguration.swift
@@ -5,6 +5,21 @@ public struct QueuesConfiguration {
 
     /// The key that stores the data about a job. Defaults to `vapor_queues`
     public var persistenceKey: String
+
+    public enum WorkerCount: ExpressibleByIntegerLiteral {
+        /// One worker per event loop.
+        case `default`
+
+        /// Specify a custom worker count.
+        case custom(Int)
+
+        /// See `ExpressibleByIntegerLiteral`.
+        public init(integerLiteral value: Int) {
+            self = .custom(value)
+        }
+    }
+    ///
+    public var workerCount: WorkerCount
     
     /// A logger
     public let logger: Logger
@@ -19,6 +34,7 @@ public struct QueuesConfiguration {
     public init(
         refreshInterval: TimeAmount = .seconds(1),
         persistenceKey: String = "vapor_queues",
+        workerCount: WorkerCount = .default,
         logger: Logger = .init(label: "codes.vapor.queues")
     ) {
         self.jobs = [:]
@@ -26,6 +42,7 @@ public struct QueuesConfiguration {
         self.logger = logger
         self.refreshInterval = refreshInterval
         self.persistenceKey = persistenceKey
+        self.workerCount = workerCount
         self.userInfo = [:]
     }
     

--- a/Sources/Queues/QueuesConfiguration.swift
+++ b/Sources/Queues/QueuesConfiguration.swift
@@ -6,6 +6,7 @@ public struct QueuesConfiguration {
     /// The key that stores the data about a job. Defaults to `vapor_queues`
     public var persistenceKey: String
 
+    /// Supported options for number of job handling workers. 
     public enum WorkerCount: ExpressibleByIntegerLiteral {
         /// One worker per event loop.
         case `default`
@@ -18,7 +19,8 @@ public struct QueuesConfiguration {
             self = .custom(value)
         }
     }
-    ///
+
+    /// Sets the number of workers used for handling jobs.
     public var workerCount: WorkerCount
     
     /// A logger


### PR DESCRIPTION
Adds a new `workerCount` property to `QueuesConfiguration` (#86, fixes #84). 

This property lets you configure how many workers will be used for handling jobs. The default value is `.default` which uses one worker per event loop. You can set a custom number of workings using `.custom(_:)` or an integer literal. 

```swift
// Use two workers for handling jobs.
app.queues.configuration.workerCount = 2
```

Each worker will be assigned an event loop round-robin. If the number of workers is larger than the number of event loops, some event loops will have multiple workers. 