### PR TITLE
Job Event Delegate Hooks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@ on:
 jobs:
   queues_xenial:
     container:
-      image: vapor/swift:5.3-xenial
+      image: swift:5.3-xenial
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: swift test --enable-test-discovery --sanitize=thread
   queues_bionic:
     container:
-      image: vapor/swift:5.3-bionic
+      image: swift:5.3-bionic
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,14 +4,14 @@ on:
 jobs:
   queues_xenial:
     container:
-      image: vapor/swift:5.2-xenial
+      image: vapor/swift:5.3-xenial
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
       - run: swift test --enable-test-discovery --sanitize=thread
   queues_bionic:
     container:
-      image: vapor/swift:5.2-bionic
+      image: vapor/swift:5.3-bionic
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/Sources/Queues/Application+Queues.swift
+++ b/Sources/Queues/Application+Queues.swift
@@ -105,6 +105,12 @@ extension Application {
             self.configuration.add(job)
         }
 
+        /// Adds a new notification hook
+        /// - Parameter hook: The hook object to add
+        public func add<N>(_ hook: N) where N: NotificationHook {
+            self.configuration.add(hook)
+        }
+
         /// Choose which provider to use
         /// - Parameter provider: The provider
         public func use(_ provider: Provider) {

--- a/Sources/Queues/Application+Queues.swift
+++ b/Sources/Queues/Application+Queues.swift
@@ -107,7 +107,7 @@ extension Application {
 
         /// Adds a new notification hook
         /// - Parameter hook: The hook object to add
-        public func add<N>(_ hook: N) where N: NotificationHook {
+        public func add<N>(_ hook: N) where N: JobEventDelegate {
             self.configuration.add(hook)
         }
 

--- a/Sources/Queues/Job.swift
+++ b/Sources/Queues/Job.swift
@@ -61,17 +61,21 @@ extension Job {
         context.eventLoop.makeSucceededFuture(())
     }
     
-    public func _error(_ context: QueueContext, _ error: Error, payload: [UInt8]) -> EventLoopFuture<Void> {
+    public func _error(_ context: QueueContext, id: String, _ error: Error, payload: [UInt8]) -> EventLoopFuture<Void> {
+        var contextCopy = context
+        contextCopy.logger[metadataKey: "job_id"] = .string(id)
         do {
-            return try self.error(context, error, Self.parsePayload(payload))
+            return try self.error(contextCopy, error, Self.parsePayload(payload))
         } catch {
             return context.eventLoop.makeFailedFuture(error)
         }
     }
     
-    public func _dequeue(_ context: QueueContext, payload: [UInt8]) -> EventLoopFuture<Void> {
+    public func _dequeue(_ context: QueueContext, id: String, payload: [UInt8]) -> EventLoopFuture<Void> {
+        var contextCopy = context
+        contextCopy.logger[metadataKey: "job_id"] = .string(id)
         do {
-            return try self.dequeue(context, Self.parsePayload(payload))
+            return try self.dequeue(contextCopy, Self.parsePayload(payload))
         } catch {
             return context.eventLoop.makeFailedFuture(error)
         }
@@ -82,6 +86,6 @@ extension Job {
 public protocol AnyJob {
     /// The name of the `Job`
     static var name: String { get }
-    func _dequeue(_ context: QueueContext, payload: [UInt8]) -> EventLoopFuture<Void>
-    func _error(_ context: QueueContext, _ error: Error, payload: [UInt8]) -> EventLoopFuture<Void>
+    func _dequeue(_ context: QueueContext, id: String, payload: [UInt8]) -> EventLoopFuture<Void>
+    func _error(_ context: QueueContext, id: String, _ error: Error, payload: [UInt8]) -> EventLoopFuture<Void>
 }

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -53,6 +53,9 @@ public struct NotificationJobData {
     /// The id of the job, assigned at dispatch
     public let id: String
 
+    /// The name of the queue (i.e. `default`)
+    public let queueName: String
+
     /// The job data to be encoded.
     public let payload: [UInt8]
 
@@ -69,8 +72,9 @@ public struct NotificationJobData {
     public let jobName: String
 
     /// Creates a new `JobStorage` holding object
-    public init(id: String, jobData: JobData) {
+    public init(id: String, queueName: String, jobData: JobData) {
         self.id = id
+        self.queueName = queueName
         self.payload = jobData.payload
         self.maxRetryCount = jobData.maxRetryCount
         self.jobName = jobData.jobName

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -29,6 +29,7 @@ extension NotificationHook {
 
 /// Data on a job sent via a notification
 public struct NotificationJobData {
+    /// The id of the job, assigned at dispatch
     public let id: String
 
     /// The job data to be encoded.

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -9,6 +9,12 @@ public protocol NotificationHook {
     ///   - eventLoop: The eventLoop
     func dispatched(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
+    /// Called when the job is dequeued
+    /// - Parameters:
+    ///   - jobId: The id of the Job
+    ///   - eventLoop: The eventLoop
+    func dequeued(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void>
+
 
     /// Called when the job succeeds
     /// - Parameters:
@@ -26,6 +32,10 @@ public protocol NotificationHook {
 
 extension NotificationHook {
     public func dispatched(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.future()
+    }
+
+    public func dequeued(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -1,0 +1,15 @@
+import NIO
+
+/// Represents an object that can receive notifications about job statuses
+public protocol NotificationHook {
+
+    /// Called when the job succeeds
+    /// - Parameter job: The `JobData` associated with the job
+    func success(job: JobData) -> EventLoopFuture<Void>
+
+    /// Called when the job returns an error
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    ///   - error: The error that caused the job to fail
+    func error(job: JobData, error: Error) -> EventLoopFuture<Void>
+}

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -51,25 +51,25 @@ extension NotificationHook {
 /// Data on a job sent via a notification
 public struct NotificationJobData {
     /// The id of the job, assigned at dispatch
-    public let id: String
+    public var id: String
 
     /// The name of the queue (i.e. `default`)
-    public let queueName: String
+    public var queueName: String
 
     /// The job data to be encoded.
-    public let payload: [UInt8]
+    public var payload: [UInt8]
 
     /// The maxRetryCount for the `Job`.
-    public let maxRetryCount: Int
+    public var maxRetryCount: Int
 
     /// A date to execute this job after
-    public let delayUntil: Date?
+    public var delayUntil: Date?
 
     /// The date this job was queued
-    public let queuedAt: Date
+    public var queuedAt: Date
 
     /// The name of the `Job`
-    public let jobName: String
+    public var jobName: String
 
     /// Creates a new `JobStorage` holding object
     public init(id: String, queueName: String, jobData: JobData) {

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -4,12 +4,25 @@ import NIO
 public protocol NotificationHook {
 
     /// Called when the job succeeds
-    /// - Parameter job: The `JobData` associated with the job
-    func success(job: JobData) -> EventLoopFuture<Void>
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    ///   - eventLoop: The eventLoop
+    func success(job: JobData, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
     /// Called when the job returns an error
     /// - Parameters:
     ///   - job: The `JobData` associated with the job
     ///   - error: The error that caused the job to fail
-    func error(job: JobData, error: Error) -> EventLoopFuture<Void>
+    ///   - eventLoop: The eventLoop
+    func error(job: JobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
+}
+
+extension NotificationHook {
+    public func success(job: JobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.future()
+    }
+
+    public func error(job: JobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.future()
+    }
 }

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -1,19 +1,19 @@
 import NIO
 
 /// Represents an object that can receive notifications about job statuses
-public protocol NotificationHook {
+public protocol JobEventDelegate {
 
     /// Called when the job is first dispatched
     /// - Parameters:
     ///   - job: The `JobData` associated with the job
     ///   - eventLoop: The eventLoop
-    func dispatched(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func dispatched(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
     /// Called when the job is dequeued
     /// - Parameters:
     ///   - jobId: The id of the Job
     ///   - eventLoop: The eventLoop
-    func dequeued(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func didDequeue(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
 
     /// Called when the job succeeds
@@ -30,12 +30,12 @@ public protocol NotificationHook {
     func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
 }
 
-extension NotificationHook {
-    public func dispatched(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+extension JobEventDelegate {
+    public func dispatched(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 
-    public func dequeued(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    public func didDequeue(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 
@@ -49,7 +49,7 @@ extension NotificationHook {
 }
 
 /// Data on a job sent via a notification
-public struct NotificationJobData {
+public struct JobEventData {
     /// The id of the job, assigned at dispatch
     public var id: String
 

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -7,22 +7,52 @@ public protocol NotificationHook {
     /// - Parameters:
     ///   - job: The `JobData` associated with the job
     ///   - eventLoop: The eventLoop
-    func success(job: JobData, eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func success(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
     /// Called when the job returns an error
     /// - Parameters:
     ///   - job: The `JobData` associated with the job
     ///   - error: The error that caused the job to fail
     ///   - eventLoop: The eventLoop
-    func error(job: JobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func error(job: NotificationJobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
 }
 
 extension NotificationHook {
-    public func success(job: JobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    public func success(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 
-    public func error(job: JobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    public func error(job: NotificationJobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
+    }
+}
+
+/// Data on a job sent via a notification
+public struct NotificationJobData {
+    public let id: String
+
+    /// The job data to be encoded.
+    public let payload: [UInt8]
+
+    /// The maxRetryCount for the `Job`.
+    public let maxRetryCount: Int
+
+    /// A date to execute this job after
+    public let delayUntil: Date?
+
+    /// The date this job was queued
+    public let queuedAt: Date
+
+    /// The name of the `Job`
+    public let jobName: String
+
+    /// Creates a new `JobStorage` holding object
+    public init(id: String, jobData: JobData) {
+        self.id = id
+        self.payload = jobData.payload
+        self.maxRetryCount = jobData.maxRetryCount
+        self.jobName = jobData.jobName
+        self.delayUntil = jobData.delayUntil
+        self.queuedAt = jobData.queuedAt
     }
 }

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -3,26 +3,37 @@ import NIO
 /// Represents an object that can receive notifications about job statuses
 public protocol NotificationHook {
 
-    /// Called when the job succeeds
+    /// Called when the job is first dispatched
     /// - Parameters:
     ///   - job: The `JobData` associated with the job
     ///   - eventLoop: The eventLoop
-    func success(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func dispatched(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void>
+
+
+    /// Called when the job succeeds
+    /// - Parameters:
+    ///   - jobId: The id of the Job
+    ///   - eventLoop: The eventLoop
+    func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
     /// Called when the job returns an error
     /// - Parameters:
-    ///   - job: The `JobData` associated with the job
+    ///   - jobId: The id of the Job
     ///   - error: The error that caused the job to fail
     ///   - eventLoop: The eventLoop
-    func error(job: NotificationJobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
+    func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
 }
 
 extension NotificationHook {
-    public func success(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    public func dispatched(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 
-    public func error(job: NotificationJobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    public func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.future()
+    }
+
+    public func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 }

--- a/Sources/Queues/Queue.swift
+++ b/Sources/Queues/Queue.swift
@@ -72,6 +72,7 @@ extension Queue {
         } catch {
             return self.eventLoop.makeFailedFuture(error)
         }
+        logger.trace("Serialized bytes for payload: \(bytes)")
         let storage = JobData(
             payload: bytes,
             maxRetryCount: maxRetryCount,
@@ -79,6 +80,7 @@ extension Queue {
             delayUntil: delayUntil,
             queuedAt: Date()
         )
+        logger.trace("Adding the ID to the storage")
         return self.set(id, to: storage).flatMap {
             self.push(id)
         }.map { _ in

--- a/Sources/Queues/Queue.swift
+++ b/Sources/Queues/Queue.swift
@@ -91,7 +91,7 @@ extension Queue {
             ])
 
             return self.configuration.notificationHooks.map {
-                $0.dispatched(job: .init(id: id.string, jobData: storage), eventLoop: self.eventLoop)
+                $0.dispatched(job: .init(id: id.string, queueName: self.queueName.string, jobData: storage), eventLoop: self.eventLoop)
             }.flatten(on: self.eventLoop).transform(to: ())
         }
     }

--- a/Sources/Queues/Queue.swift
+++ b/Sources/Queues/Queue.swift
@@ -83,16 +83,19 @@ extension Queue {
         logger.trace("Adding the ID to the storage")
         return self.set(id, to: storage).flatMap {
             self.push(id)
-        }.flatMap { _ in
+        }.map { _ in
             self.logger.info("Dispatched queue job", metadata: [
                 "job_id": .string(id.string),
                 "job_name": .string(job.name),
                 "queue": .string(self.queueName.string)
             ])
 
-            return self.configuration.notificationHooks.map {
+            _ = self.configuration.notificationHooks.map {
                 $0.dispatched(job: .init(id: id.string, queueName: self.queueName.string, jobData: storage), eventLoop: self.eventLoop)
-            }.flatten(on: self.eventLoop).transform(to: ())
+            }.flatten(on: self.eventLoop).flatMapError { error in
+                self.logger.error("Could not send dispatched notification: \(error)")
+                return self.eventLoop.future()
+            }
         }
     }
 }

--- a/Sources/Queues/QueueContext.swift
+++ b/Sources/Queues/QueueContext.swift
@@ -12,7 +12,7 @@ public struct QueueContext {
     public let application: Application
     
     /// The logger object
-    public let logger: Logger
+    public var logger: Logger
     
     /// An event loop to run the process on
     public let eventLoop: EventLoop

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -79,7 +79,7 @@ public struct QueueWorker {
             logger.trace("Ran job successfully")
             logger.trace("Sending success notification hooks")
             return self.queue.configuration.notificationHooks.map {
-                $0.success(job: jobData)
+                $0.success(job: jobData, eventLoop: self.queue.context.eventLoop)
             }.flatten(on: self.queue.context.eventLoop)
         }.flatMapError { error in
             logger.trace("Job failed (remaining tries: \(remainingTries)")
@@ -92,7 +92,7 @@ public struct QueueWorker {
 
                 logger.trace("Sending failure notification hooks")
                 let failureNotificationHooks = self.queue.configuration.notificationHooks.map {
-                    $0.error(job: jobData, error: error)
+                    $0.error(job: jobData, error: error, eventLoop: self.queue.context.eventLoop)
                 }.flatten(on: self.queue.context.eventLoop)
 
                 return job._error(self.queue.context, error, payload: payload).and(failureNotificationHooks).transform(to: ())

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -79,7 +79,7 @@ public struct QueueWorker {
             logger.trace("Ran job successfully")
             logger.trace("Sending success notification hooks")
             return self.queue.configuration.notificationHooks.map {
-                $0.success(job: jobData, eventLoop: self.queue.context.eventLoop)
+                $0.success(job: .init(id: id.string, jobData: jobData), eventLoop: self.queue.context.eventLoop)
             }.flatten(on: self.queue.context.eventLoop)
         }.flatMapError { error in
             logger.trace("Job failed (remaining tries: \(remainingTries)")
@@ -92,7 +92,7 @@ public struct QueueWorker {
 
                 logger.trace("Sending failure notification hooks")
                 let failureNotificationHooks = self.queue.configuration.notificationHooks.map {
-                    $0.error(job: jobData, error: error, eventLoop: self.queue.context.eventLoop)
+                    $0.error(job: .init(id: id.string, jobData: jobData), error: error, eventLoop: self.queue.context.eventLoop)
                 }.flatten(on: self.queue.context.eventLoop)
 
                 return job._error(self.queue.context, error, payload: payload).and(failureNotificationHooks).transform(to: ())

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -74,7 +74,7 @@ public struct QueueWorker {
         jobData: JobData
     ) -> EventLoopFuture<Void> {
         logger.trace("Running the queue job (remaining tries: \(remainingTries)")
-        let futureJob = job._dequeue(self.queue.context, payload: payload)
+        let futureJob = job._dequeue(self.queue.context, id: id.string, payload: payload)
         return futureJob.flatMap { complete in
             logger.trace("Ran job successfully")
             logger.trace("Sending success notification hooks")
@@ -95,7 +95,7 @@ public struct QueueWorker {
                     $0.error(jobId: id.string, error: error, eventLoop: self.queue.context.eventLoop)
                 }.flatten(on: self.queue.context.eventLoop)
 
-                return job._error(self.queue.context, error, payload: payload).and(failureNotificationHooks).transform(to: ())
+                return job._error(self.queue.context, id: id.string, error, payload: payload).and(failureNotificationHooks).transform(to: ())
             } else {
                 logger.error("Job failed, retrying... \(error)", metadata: [
                     "job_id": .string(id.string),

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -79,7 +79,7 @@ public struct QueueWorker {
             logger.trace("Ran job successfully")
             logger.trace("Sending success notification hooks")
             return self.queue.configuration.notificationHooks.map {
-                $0.success(job: .init(id: id.string, jobData: jobData), eventLoop: self.queue.context.eventLoop)
+                $0.success(jobId: id.string, eventLoop: self.queue.context.eventLoop)
             }.flatten(on: self.queue.context.eventLoop)
         }.flatMapError { error in
             logger.trace("Job failed (remaining tries: \(remainingTries)")
@@ -92,7 +92,7 @@ public struct QueueWorker {
 
                 logger.trace("Sending failure notification hooks")
                 let failureNotificationHooks = self.queue.configuration.notificationHooks.map {
-                    $0.error(job: .init(id: id.string, jobData: jobData), error: error, eventLoop: self.queue.context.eventLoop)
+                    $0.error(jobId: id.string, error: error, eventLoop: self.queue.context.eventLoop)
                 }.flatten(on: self.queue.context.eventLoop)
 
                 return job._error(self.queue.context, error, payload: payload).and(failureNotificationHooks).transform(to: ())

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -43,27 +43,31 @@ public struct QueueWorker {
                 }
 
                 logger.trace("Sending dequeued notification hooks")
-                return self.queue.configuration.notificationHooks.map {
-                    $0.dequeued(jobId: id.string, eventLoop: self.queue.eventLoop)
-                }.flatten(on: self.queue.eventLoop).flatMap { _ in
-                    logger.info("Dequeing job", metadata: [
-                        "job_id": .string(id.string),
-                        "job_name": .string(data.jobName),
-                        "queue": .string(self.queue.queueName.string)
-                    ])
 
-                    return self.run(
-                        id: id,
-                        name: data.jobName,
-                        job: job,
-                        payload: data.payload,
-                        logger: logger,
-                        remainingTries: data.maxRetryCount,
-                        jobData: data
-                    ).flatMap {
-                        logger.trace("Job done being run")
-                        return self.queue.clear(id)
-                    }
+                _ = self.queue.configuration.notificationHooks.map {
+                    $0.didDequeue(jobId: id.string, eventLoop: self.queue.eventLoop)
+                }.flatten(on: self.queue.eventLoop).flatMapError { error in
+                    logger.error("Could not send didDequeue notification: \(error)")
+                    return self.queue.eventLoop.future()
+                }
+
+                logger.info("Dequeing job", metadata: [
+                    "job_id": .string(id.string),
+                    "job_name": .string(data.jobName),
+                    "queue": .string(self.queue.queueName.string)
+                ])
+
+                return self.run(
+                    id: id,
+                    name: data.jobName,
+                    job: job,
+                    payload: data.payload,
+                    logger: logger,
+                    remainingTries: data.maxRetryCount,
+                    jobData: data
+                ).flatMap {
+                    logger.trace("Job done being run")
+                    return self.queue.clear(id)
                 }
             }
         }
@@ -80,12 +84,17 @@ public struct QueueWorker {
     ) -> EventLoopFuture<Void> {
         logger.trace("Running the queue job (remaining tries: \(remainingTries)")
         let futureJob = job._dequeue(self.queue.context, id: id.string, payload: payload)
-        return futureJob.flatMap { complete in
+        return futureJob.map { complete in
             logger.trace("Ran job successfully")
             logger.trace("Sending success notification hooks")
-            return self.queue.configuration.notificationHooks.map {
+            _ = self.queue.configuration.notificationHooks.map {
                 $0.success(jobId: id.string, eventLoop: self.queue.context.eventLoop)
-            }.flatten(on: self.queue.context.eventLoop)
+            }.flatten(on: self.queue.context.eventLoop).flatMapError { error in
+                self.queue.logger.error("Could not send success notification: \(error)")
+                return self.queue.context.eventLoop.future()
+            }
+
+            return complete
         }.flatMapError { error in
             logger.trace("Job failed (remaining tries: \(remainingTries)")
             if remainingTries == 0 {
@@ -96,11 +105,14 @@ public struct QueueWorker {
                 ])
 
                 logger.trace("Sending failure notification hooks")
-                let failureNotificationHooks = self.queue.configuration.notificationHooks.map {
+                _ = self.queue.configuration.notificationHooks.map {
                     $0.error(jobId: id.string, error: error, eventLoop: self.queue.context.eventLoop)
-                }.flatten(on: self.queue.context.eventLoop)
+                }.flatten(on: self.queue.context.eventLoop).flatMapError { error in
+                    self.queue.logger.error("Failed to send error notification: \(error)")
+                    return self.queue.context.eventLoop.future()
+                }
 
-                return job._error(self.queue.context, id: id.string, error, payload: payload).and(failureNotificationHooks).transform(to: ())
+                return job._error(self.queue.context, id: id.string, error, payload: payload)
             } else {
                 logger.error("Job failed, retrying... \(error)", metadata: [
                     "job_id": .string(id.string),

--- a/Sources/Queues/QueuesConfiguration.swift
+++ b/Sources/Queues/QueuesConfiguration.swift
@@ -55,6 +55,7 @@ public struct QueuesConfiguration {
     mutating public func add<J>(_ job: J)
         where J: Job
     {
+        self.logger.trace("Adding job type: \(J.name)")
         if let existing = self.jobs[J.name] {
             self.logger.warning("A job is already registered with key \(J.name): \(existing)")
         }
@@ -74,6 +75,7 @@ public struct QueuesConfiguration {
     mutating internal func schedule<J>(_ job: J, builder: ScheduleBuilder = ScheduleBuilder()) -> ScheduleBuilder
         where J: ScheduledJob
     {
+        self.logger.trace("Scheduling \(job.name)")
         let storage = AnyScheduledJob(job: job, scheduler: builder)
         self.scheduledJobs.append(storage)
         return builder

--- a/Sources/Queues/QueuesConfiguration.swift
+++ b/Sources/Queues/QueuesConfiguration.swift
@@ -31,6 +31,7 @@ public struct QueuesConfiguration {
     
     var jobs: [String: AnyJob]
     var scheduledJobs: [AnyScheduledJob]
+    var notificationHooks: [NotificationHook]
     
     /// Creates an empty `JobsConfig`
     public init(
@@ -46,6 +47,7 @@ public struct QueuesConfiguration {
         self.persistenceKey = persistenceKey
         self.workerCount = workerCount
         self.userInfo = [:]
+        self.notificationHooks = []
     }
     
     /// Adds a new `Job` to the queue configuration.
@@ -79,5 +81,14 @@ public struct QueuesConfiguration {
         let storage = AnyScheduledJob(job: job, scheduler: builder)
         self.scheduledJobs.append(storage)
         return builder
+    }
+
+    /// Adds a notification hook that can receive status updates about jobs
+    /// - Parameter hook: The `NotificationHook` object
+    mutating public func add<N>(_ hook: N)
+        where N: NotificationHook
+    {
+        self.logger.trace("Adding notification hook")
+        self.notificationHooks.append(hook)
     }
 }

--- a/Sources/Queues/QueuesConfiguration.swift
+++ b/Sources/Queues/QueuesConfiguration.swift
@@ -31,7 +31,7 @@ public struct QueuesConfiguration {
     
     var jobs: [String: AnyJob]
     var scheduledJobs: [AnyScheduledJob]
-    var notificationHooks: [NotificationHook]
+    var notificationHooks: [JobEventDelegate]
     
     /// Creates an empty `JobsConfig`
     public init(
@@ -86,7 +86,7 @@ public struct QueuesConfiguration {
     /// Adds a notification hook that can receive status updates about jobs
     /// - Parameter hook: The `NotificationHook` object
     mutating public func add<N>(_ hook: N)
-        where N: NotificationHook
+        where N: JobEventDelegate
     {
         self.logger.trace("Adding notification hook")
         self.notificationHooks.append(hook)

--- a/Sources/Queues/ScheduledJob.swift
+++ b/Sources/Queues/ScheduledJob.swift
@@ -29,6 +29,7 @@ extension AnyScheduledJob {
     }
 
     func schedule(context: QueueContext) -> Task? {
+        context.logger.trace("Beginning the scheduler process")
         guard let date = self.scheduler.nextDate() else {
             context.logger.debug("No date scheduled for \(self.job.name)")
             return nil
@@ -41,6 +42,7 @@ extension AnyScheduledJob {
         ) { task in
             // always cancel
             task.cancel()
+            context.logger.trace("Running the scheduled job \(self.job.name)")
             self.job.run(context: context).cascade(to: promise)
         }
         return .init(task: task, done: promise.futureResult)

--- a/Tests/QueuesTests/QueueTests.swift
+++ b/Tests/QueuesTests/QueueTests.swift
@@ -261,16 +261,16 @@ final class QueueTests: XCTestCase {
     }
 }
 
-class DispatchHook: NotificationHook {
+class DispatchHook: JobEventDelegate {
     static var successHit = false
 
-    func dispatched(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func dispatched(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         Self.successHit = true
         return eventLoop.future()
     }
 }
 
-class SuccessHook: NotificationHook {
+class SuccessHook: JobEventDelegate {
     static var successHit = false
 
     func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
@@ -279,7 +279,7 @@ class SuccessHook: NotificationHook {
     }
 }
 
-class ErrorHook: NotificationHook {
+class ErrorHook: JobEventDelegate {
     static var errorCount = 0
 
     func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
@@ -288,10 +288,10 @@ class ErrorHook: NotificationHook {
     }
 }
 
-class DequeuedHook: NotificationHook {
+class DequeuedHook: JobEventDelegate {
     static var successHit = false
 
-    func dequeued(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func didDequeue(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         Self.successHit = true
         return eventLoop.future()
     }

--- a/Tests/QueuesTests/QueueTests.swift
+++ b/Tests/QueuesTests/QueueTests.swift
@@ -257,7 +257,7 @@ final class QueueTests: XCTestCase {
 class SuccessHook: NotificationHook {
     static var successHit = false
 
-    func success(job: JobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func success(job: NotificationJobData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         Self.successHit = true
         return eventLoop.future()
     }
@@ -266,7 +266,7 @@ class SuccessHook: NotificationHook {
 class ErrorHook: NotificationHook {
     static var errorCount = 0
 
-    func error(job: JobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+    func error(job: NotificationJobData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         Self.errorCount += 1
         return eventLoop.future()
     }


### PR DESCRIPTION
This release adds a protocol called `JobEventDelegate` which allows ends users to "hook" into the status of jobs that are being run. Each notification hook can specify a success handler, an error handler, or both. 

To get started, conform an object to `JobEventDelegate` and implement any of the methods you'd like:

```swift
struct MyEventDelegate: JobEventDelegate {
    public func dispatched(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
        eventLoop.future()
    }

    public func didDequeue(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
        eventLoop.future()
    }

    public func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
        eventLoop.future()
    }

    public func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
        eventLoop.future()
    }
}
```

Then, add it in your configuration file:

```swift
app.queues.add(MyEventDelegate())
```

This PR also adds a bunch of `trace` logging for better debugging 