### PR TITLE
Fix building with Swift 5.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,5 @@ jobs:
           - swift:5.3-bionic
     container: ${{ matrix.image }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - run: swift test --enable-test-discovery --sanitize=thread

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,17 +2,16 @@ name: test
 on:
   - pull_request
 jobs:
-  queues_xenial:
-    container:
-      image: swift:5.3-xenial
+  linux:
     runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v1
-      - run: swift test --enable-test-discovery --sanitize=thread
-  queues_bionic:
-    container:
-      image: swift:5.3-bionic
-    runs-on: ubuntu-latest
+    strategy:
+      matrix: 
+        image: 
+          - swift:5.2-xenial
+          - swift:5.2-bionic
+          - swift:5.3-xenial
+          - swift:5.3-bionic
+    container: ${{ matrix.image }}
     steps:
       - uses: actions/checkout@v1
       - run: swift test --enable-test-discovery --sanitize=thread

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -18,12 +18,12 @@ public struct QueueWorker {
         return self.queue.pop().flatMap { id in
             //No job found, go to the next iteration
             guard let id = id else {
-                queue.logger.trace("Did not receive ID from pop")
+                self.queue.logger.trace("Did not receive ID from pop")
                 return self.queue.eventLoop.makeSucceededFuture(())
             }
 
-            queue.logger.trace("Received job \(id)")
-            queue.logger.trace("Getting data for job \(id)")
+            self.queue.logger.trace("Received job \(id)")
+            self.queue.logger.trace("Getting data for job \(id)")
 
             return self.queue.get(id).flatMap { data in
                 var logger = self.queue.logger


### PR DESCRIPTION
Enables Queues to be built with Swift 5.2 again by adding missing `self` where needed. Also adds a test scenario for Swift 5.2 to prevent this from breaking in the future.