### PR TITLE
Allow delaying retires of failed job

### DIFF
--- a/Sources/Queues/Job.swift
+++ b/Sources/Queues/Job.swift
@@ -31,7 +31,8 @@ public protocol Job: AnyJob {
     ///
     /// - Parameters:
     ///     - attempt: Number of job attempts which failed
-    /// - Returns: Number of seconds for which next retry will be delayed
+    /// - Returns: Number of seconds for which next retry will be delayed.
+    ///   Return `-1` if you want to retry job immediately without putting it back to the queue.
     func nextRetryIn(attempt: Int) -> Int
     
     static func serializePayload(_ payload: Payload) throws -> [UInt8]
@@ -70,7 +71,7 @@ extension Job {
 
     /// See `Job`.`nextRetryIn`
     public func nextRetryIn(attempt: Int) -> Int {
-        return 0
+        return -1
     }
 
     public func _nextRetryIn(attempt: Int) -> Int {

--- a/Sources/Queues/JobData.swift
+++ b/Sources/Queues/JobData.swift
@@ -6,7 +6,7 @@ public struct JobData: Codable {
     /// The maxRetryCount for the `Job`.
     public let maxRetryCount: Int
 
-    /// The attempts done to run the `Job`.
+    /// The number of attempts made to run the `Job`.
     public let attempts: Int?
     
     /// A date to execute this job after

--- a/Sources/Queues/JobData.swift
+++ b/Sources/Queues/JobData.swift
@@ -5,6 +5,9 @@ public struct JobData: Codable {
     
     /// The maxRetryCount for the `Job`.
     public let maxRetryCount: Int
+
+    /// The attempts done to run the `Job`.
+    public let attempts: Int?
     
     /// A date to execute this job after
     public let delayUntil: Date?
@@ -21,12 +24,14 @@ public struct JobData: Codable {
         maxRetryCount: Int,
         jobName: String,
         delayUntil: Date?,
-        queuedAt: Date
+        queuedAt: Date,
+        attempts: Int = 0
     ) {
         self.payload = payload
         self.maxRetryCount = maxRetryCount
         self.jobName = jobName
         self.delayUntil = delayUntil
         self.queuedAt = queuedAt
+        self.attempts = attempts
     }
 }

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -133,15 +133,15 @@ public struct QueueWorker {
     }
 
     private func retry(
-            id: JobIdentifier,
-            name: String,
-            job: AnyJob,
-            payload: [UInt8],
-            logger: Logger,
-            remainingTries: Int,
-            attempts: Int?,
-            jobData: JobData,
-            error: Error
+        id: JobIdentifier,
+        name: String,
+        job: AnyJob,
+        payload: [UInt8],
+        logger: Logger,
+        remainingTries: Int,
+        attempts: Int?,
+        jobData: JobData,
+        error: Error
     ) -> EventLoopFuture<Void> {
         let attempts = attempts ?? 0
         let delayInSeconds = job._nextRetryIn(attempt: attempts + 1)
@@ -152,14 +152,14 @@ public struct QueueWorker {
                 "queue": .string(self.queue.queueName.string)
             ])
             return self.run(
-                    id: id,
-                    name: name,
-                    job: job,
-                    payload: payload,
-                    logger: logger,
-                    remainingTries: remainingTries - 1,
-                    attempts: attempts + 1,
-                    jobData: jobData
+                id: id,
+                name: name,
+                job: job,
+                payload: payload,
+                logger: logger,
+                remainingTries: remainingTries - 1,
+                attempts: attempts + 1,
+                jobData: jobData
             )
         } else {
             logger.error("Job failed, retrying in \(delayInSeconds)s... \(error)", metadata: [
@@ -168,12 +168,12 @@ public struct QueueWorker {
                 "queue": .string(self.queue.queueName.string)
             ])
             let storage = JobData(
-                    payload: jobData.payload,
-                    maxRetryCount: remainingTries - 1,
-                    jobName: jobData.jobName,
-                    delayUntil: Date(timeIntervalSinceNow: Double(delayInSeconds)),
-                    queuedAt: jobData.queuedAt,
-                    attempts: attempts + 1
+                payload: jobData.payload,
+                maxRetryCount: remainingTries - 1,
+                jobName: jobData.jobName,
+                delayUntil: Date(timeIntervalSinceNow: Double(delayInSeconds)),
+                queuedAt: jobData.queuedAt,
+                attempts: attempts + 1
             )
             return self.queue.clear(id).flatMap {
                 self.queue.set(id, to: storage)

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -157,7 +157,7 @@ public struct QueueWorker {
                     job: job,
                     payload: payload,
                     logger: logger,
-                    remainingTries: remainingTries - 1 ,
+                    remainingTries: remainingTries - 1,
                     attempts: attempts + 1,
                     jobData: jobData
             )
@@ -175,7 +175,9 @@ public struct QueueWorker {
                     queuedAt: jobData.queuedAt,
                     attempts: attempts + 1
             )
-            return self.queue.set(id, to: storage).flatMap {
+            return self.queue.clear(id).flatMap {
+                self.queue.set(id, to: storage)
+            }.flatMap {
                 self.queue.push(id)
             }
         }

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -145,7 +145,7 @@ public struct QueueWorker {
     ) -> EventLoopFuture<Void> {
         let attempts = attempts ?? 0
         let delayInSeconds = job._nextRetryIn(attempt: attempts + 1)
-        if delayInSeconds == 0 {
+        if delayInSeconds == -1 {
             logger.error("Job failed, retrying... \(error)", metadata: [
                 "job_id": .string(id.string),
                 "job_name": .string(name),

--- a/Tests/QueuesTests/QueueTests.swift
+++ b/Tests/QueuesTests/QueueTests.swift
@@ -297,7 +297,7 @@ final class QueueTests: XCTestCase {
         XCTAssert(app.queues.test.contains(Baz.self))
         XCTAssertNotNil(job)
 
-        sleep(2)
+        sleep(1)
 
         try app.queues.queue.worker.run().wait()
         XCTAssertEqual(SuccessHook.successHit, false)
@@ -469,7 +469,7 @@ struct Baz: Job {
     }
 
     func nextRetryIn(attempt: Int) -> Int {
-        return 2*attempt
+        return attempt
     }
 }
 


### PR DESCRIPTION
Added possibility of delaying retires of failed jobs.

Example usage
```swift
struct SomeJob: Job {
    func dequeue(_ context: QueueContext, _ payload: Payload) -> EventLoopFuture<Void> {
        ....
    }

    // Exponential backoff
    func nextRetryIn(attempt: Int) -> Int {
        return pow(2, attempt)
    }
}
```
