### PR TITLE
Update Supported Swift Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,22 +2,8 @@ name: test
 on: { pull_request: {} }
 
 jobs:
-  getcidata:
-    runs-on: ubuntu-latest
-    outputs:
-      environments: ${{ steps.output.outputs.environments }}
-    steps:
-      - id: output
-        run: |
-          envblob="$(curl -fsSL https://raw.githubusercontent.com/vapor/ci/main/pr-environments.json | jq -cMj '.')"
-          echo "::set-output name=environments::${envblob}"
-        
-  test-queues:
-    runs-on: ubuntu-latest
-    container: swiftlang/swift:nightly-5.5-focal
-    steps: 
-      - name: Check out Queues
-        uses: actions/checkout@v2
-      - name: Run tests with Thread Sanitizer
-        timeout-minutes: 30
-        run: swift test --enable-test-discovery --sanitize=thread
+  unit-tests:
+     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+     with:
+       with_coverage: false
+       with_tsan: true

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)