### PR TITLE
Add ability to use custom `Calendar` in `ScheduleBuilder`

### DIFF
--- a/Sources/Queues/ScheduleBuilder.swift
+++ b/Sources/Queues/ScheduleBuilder.swift
@@ -3,6 +3,7 @@ import struct Foundation.Calendar
 
 /// An object that can be used to build a scheduled job
 public final class ScheduleBuilder {
+    
     /// Months of the year
     public enum Month: Int {
         case january = 1
@@ -374,12 +375,15 @@ public final class ScheduleBuilder {
         if let month = self.month {
             components.month = month.rawValue
         }
-        return Calendar.current.nextDate(
+        return calendar.nextDate(
             after: current,
             matching: components,
             matchingPolicy: .strict
         )
     }
+    
+    /// The caledar used to compute the next date
+    let calendar: Calendar
     
     /// Date to perform task (one-off job)
     var date: Date?
@@ -391,7 +395,9 @@ public final class ScheduleBuilder {
     var second: Second?
     var millisecond: Int?
 
-    public init() { }
+    public init(calendar: Calendar = .current) {
+        self.calendar = calendar
+    }
 
     // MARK: Helpers
     

--- a/Tests/QueuesTests/ScheduleBuilderTests.swift
+++ b/Tests/QueuesTests/ScheduleBuilderTests.swift
@@ -133,6 +133,27 @@ final class ScheduleBuilderTests: XCTestCase {
             Date(year: 2020, month: 5, day: 23, hour: 14, minute: 58)
         )
     }
+    
+    func testCustomCalendarBuilder() throws {
+        
+        let est = Calendar.calendar(timezone: "EST")
+        let mst = Calendar.calendar(timezone: "MST")
+        
+        // Create a date at 8:00pm EST
+        let estDate = Date(calendar: est, hour: 20, minute: 00)
+        
+        // Schedule it for 7:00pm MST
+        let builder = ScheduleBuilder(calendar: mst)
+        builder.daily().at("7:00pm")
+        
+        XCTAssertEqual(
+            builder.nextDate(current: estDate),
+            // one hour later
+            Date(calendar: est, hour: 21, minute: 00)
+        )
+    
+    }
+    
 }
 
 
@@ -144,35 +165,8 @@ final class Cleanup: ScheduledJob {
 }
 
 extension Date {
-    var year: Int {
-        Calendar.current.component(.year, from: self)
-    }
-    
-    var month: Int {
-        Calendar.current.component(.month, from: self)
-    }
-    
-    var weekday: Int {
-        Calendar.current.component(.weekday, from: self)
-    }
-    
-    var day: Int {
-        Calendar.current.component(.day, from: self)
-    }
-    
-    var hour: Int {
-        Calendar.current.component(.hour, from: self)
-    }
-    
-    var minute: Int {
-        Calendar.current.component(.minute, from: self)
-    }
-    
-    var second: Int {
-        Calendar.current.component(.second, from: self)
-    }
-    
     init(
+        calendar: Calendar = .current,
         year: Int = 2020,
         month: Int = 1,
         day: Int = 1,
@@ -181,8 +175,16 @@ extension Date {
         second: Int = 0
     ) {
         self = DateComponents(
-            calendar: .current,
+            calendar: calendar,
             year: year, month: month, day: day, hour: hour, minute: minute, second: second
         ).date!
+    }
+}
+
+extension Calendar {
+    fileprivate static func calendar(timezone identifier: String) -> Calendar {
+        var calendar = Calendar.current
+        calendar.timeZone = TimeZone(identifier: identifier)!
+        return calendar
     }
 }


### PR DESCRIPTION
This PR introduces the ability to pass a custom `Calendar` to the `ScheduleBuilder`.

I ran into an edge case where I have queues deployed across multiple regions and needed to schedule jobs based on specific time zones.

I also cleaned up some unused computed properties in the `ScheduleBuilderTests` suite.

