### PR TITLE
Add async job hooks

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.6
 import PackageDescription
 
 let package = Package(
@@ -12,7 +12,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0")
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.47.0"),
     ],
     targets: [
         .target(name: "Queues", dependencies: [

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.5.2
 import PackageDescription
 
 let package = Package(

--- a/Sources/Queues/AsyncJob.swift
+++ b/Sources/Queues/AsyncJob.swift
@@ -4,7 +4,7 @@ import Foundation
 
 #if compiler(>=5.5) && canImport(_Concurrency)
 /// A task that can be queued for future execution.
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncJob: Job {
     /// The data associated with a job
     associatedtype Payload
@@ -41,7 +41,7 @@ public protocol AsyncJob: Job {
     static func parsePayload(_ bytes: [UInt8]) throws -> Payload
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncJob where Payload: Codable {
     
     /// Serialize a payload into Data
@@ -57,7 +57,7 @@ extension AsyncJob where Payload: Codable {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncJob {
     /// The jobName of the Job
     public static var name: String {

--- a/Sources/Queues/AsyncJobEventDelegate.swift
+++ b/Sources/Queues/AsyncJobEventDelegate.swift
@@ -1,0 +1,60 @@
+#if compiler(>=5.5) && canImport(_Concurrency)
+import NIOCore
+
+/// Represents an object that can receive notifications about job statuses
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+public protocol AsyncJobEventDelegate: JobEventDelegate {
+    /// Called when the job is first dispatched
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    func dispatched(job: JobEventData) async throws
+
+    /// Called when the job is dequeued
+    /// - Parameters:
+    ///   - jobId: The id of the Job
+    func didDequeue(jobId: String) async throws
+
+    /// Called when the job succeeds
+    /// - Parameters:
+    ///   - jobId: The id of the Job
+    func success(jobId: String) async throws
+
+    /// Called when the job returns an error
+    /// - Parameters:
+    ///   - jobId: The id of the Job
+    ///   - error: The error that caused the job to fail
+    func error(jobId: String, error: Error) async throws
+}
+
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
+extension AsyncJobEventDelegate {
+    public func dispatched(job: JobEventData) async throws { }
+    public func didDequeue(jobId: String) async throws { }
+    public func success(jobId: String) async throws { }
+    public func error(jobId: String, error: Error) async throws { }
+    
+    public func dispatched(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.makeFutureWithTask {
+            try await self.dispatched(job: job)
+        }
+    }
+    
+    public func didDequeue(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.makeFutureWithTask {
+            try await self.didDequeue(jobId: jobId)
+        }
+    }
+    
+    public func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.makeFutureWithTask {
+            try await self.success(jobId: jobId)
+        }
+    }
+    
+    public func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.makeFutureWithTask {
+            try await self.error(jobId: jobId, error: error)
+        }
+    }
+}
+#endif

--- a/Sources/Queues/AsyncScheduledJob.swift
+++ b/Sources/Queues/AsyncScheduledJob.swift
@@ -4,7 +4,7 @@ import Foundation
 
 #if compiler(>=5.5) && canImport(_Concurrency)
 /// Describes a job that can be scheduled and repeated
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 public protocol AsyncScheduledJob: ScheduledJob {
     var name: String { get }
     
@@ -13,7 +13,7 @@ public protocol AsyncScheduledJob: ScheduledJob {
     func run(context: QueueContext) async throws
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 extension AsyncScheduledJob {
     public var name: String { "\(Self.self)" }
     

--- a/Sources/Queues/Queue+Async.swift
+++ b/Sources/Queues/Queue+Async.swift
@@ -9,7 +9,7 @@ extension Queue {
     ///   - payload: The payload data to be dispatched
     ///   - maxRetryCount: Number of times to retry this job on failure
     ///   - delayUntil: Delay the processing of this job until a certain date
-    @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+    @available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
     public func dispatch<J>(
         _ job: J.Type,
         _ payload: J.Payload,

--- a/Sources/Queues/QueuesCommand.swift
+++ b/Sources/Queues/QueuesCommand.swift
@@ -1,6 +1,6 @@
 import Vapor
-import class NIOConcurrencyHelpers.NIOAtomic
-import class NIO.RepeatedTask
+import NIOConcurrencyHelpers
+import NIOCore
 
 /// The command to start the Queue job
 public final class QueuesCommand: Command {
@@ -26,7 +26,7 @@ public final class QueuesCommand: Command {
     private let application: Application
     private var jobTasks: [RepeatedTask]
     private var scheduledTasks: [String: AnyScheduledJob.Task]
-    private var lock: Lock
+    private var lock: NIOLock
     private var signalSources: [DispatchSourceSignal]
     private var didShutdown: Bool
     

--- a/Sources/XCTQueues/TestQueueDriver.swift
+++ b/Sources/XCTQueues/TestQueueDriver.swift
@@ -1,5 +1,6 @@
 import Queues
 import Vapor
+import NIOConcurrencyHelpers
 
 extension Application.Queues.Provider {
     public static var test: Self {
@@ -11,7 +12,7 @@ extension Application.Queues.Provider {
 }
 
 struct TestQueuesDriver: QueuesDriver {
-    let lock: Lock
+    let lock: NIOLock
 
     init() {
         self.lock = .init()
@@ -80,7 +81,7 @@ extension Application.Queues {
 }
 
 struct TestQueue: Queue {
-    let lock: Lock
+    let lock: NIOLock
     let context: QueueContext
     
     func get(_ id: JobIdentifier) -> EventLoopFuture<JobData> {

--- a/Tests/QueuesTests/AsyncQueueTests.swift
+++ b/Tests/QueuesTests/AsyncQueueTests.swift
@@ -6,7 +6,7 @@ import XCTQueues
 @testable import Vapor
 import NIOConcurrencyHelpers
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 final class AsyncQueueTests: XCTestCase {
     func testAsyncJob() throws {
         let app = Application(.testing)
@@ -41,7 +41,7 @@ final class AsyncQueueTests: XCTestCase {
     }
 }
 
-@available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
+@available(macOS 10.15, iOS 13, tvOS 13, watchOS 6, *)
 struct MyAsyncJob: AsyncJob {
     let promise: EventLoopPromise<Void>
     

--- a/Tests/QueuesTests/QueueTests.swift
+++ b/Tests/QueuesTests/QueueTests.swift
@@ -345,7 +345,7 @@ class DequeuedHook: JobEventDelegate {
 
 final class WorkerCountDriver: QueuesDriver {
     let count: EventLoopPromise<Int>
-    let lock: Lock
+    let lock: NIOLock
     var recordedEventLoops: Set<ObjectIdentifier>
 
     init(count: EventLoopPromise<Int>) {


### PR DESCRIPTION
* Bump Swift version to 5.5.2
* Backport concurrency to older platforms
* Add `AsyncJobEventDelegate` for async hooks
* Replace `Lock` with `NIOLock`