### PR TITLE
Fix quotes

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,3 +1,3 @@
 version: 1
 metadata:
-  authors: “Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community.”
+  authors: Maintained by the Vapor Core Team with hundreds of contributions from the Vapor Community.


### PR DESCRIPTION
I noticed that the authors display with extra quotes in SPI

<img width="516" alt="CleanShot 2023-01-30 at 10 11 03@2x" src="https://user-images.githubusercontent.com/65520/215434992-018e855f-c634-449b-b990-777ffa6a6359.png">

which is probably unintended. It's because the yml file contains "smart quotes".