### PR TITLE
Add `didDequeue`, `success` and `error` notification hook methods with `JobEventData`

### DIFF
--- a/Sources/Queues/AsyncJobEventDelegate.swift
+++ b/Sources/Queues/AsyncJobEventDelegate.swift
@@ -12,23 +12,42 @@ public protocol AsyncJobEventDelegate: JobEventDelegate {
     ///   - jobId: The id of the Job
     func didDequeue(jobId: String) async throws
 
+    /// Called when the job is dequeued
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    func didDequeue(job: JobEventData) async throws
+
     /// Called when the job succeeds
     /// - Parameters:
     ///   - jobId: The id of the Job
     func success(jobId: String) async throws
+
+    /// Called when the job succeeds
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    func success(job: JobEventData) async throws
 
     /// Called when the job returns an error
     /// - Parameters:
     ///   - jobId: The id of the Job
     ///   - error: The error that caused the job to fail
     func error(jobId: String, error: Error) async throws
+
+    /// Called when the job returns an error
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    ///   - error: The error that caused the job to fail
+    func error(job: JobEventData, error: Error) async throws
 }
 
 extension AsyncJobEventDelegate {
     public func dispatched(job: JobEventData) async throws { }
     public func didDequeue(jobId: String) async throws { }
+    public func didDequeue(job: JobEventData) async throws { }
     public func success(jobId: String) async throws { }
+    public func success(job: JobEventData) async throws { }
     public func error(jobId: String, error: Error) async throws { }
+    public func error(job: JobEventData) async throws { }
     
     public func dispatched(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.makeFutureWithTask {
@@ -41,6 +60,12 @@ extension AsyncJobEventDelegate {
             try await self.didDequeue(jobId: jobId)
         }
     }
+
+    public func didDequeue(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.makeFutureWithTask {
+            try await self.didDequeue(job: job)
+        }
+    }
     
     public func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.makeFutureWithTask {
@@ -48,9 +73,21 @@ extension AsyncJobEventDelegate {
         }
     }
     
+    public func success(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.makeFutureWithTask {
+            try await self.success(job: job)
+        }
+    }
+
     public func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.makeFutureWithTask {
             try await self.error(jobId: jobId, error: error)
+        }
+    }
+
+    public func error(job: JobEventData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.makeFutureWithTask {
+            try await self.error(job: job, error: error)
         }
     }
 }

--- a/Sources/Queues/AsyncJobEventDelegate.swift
+++ b/Sources/Queues/AsyncJobEventDelegate.swift
@@ -47,7 +47,7 @@ extension AsyncJobEventDelegate {
     public func success(jobId: String) async throws { }
     public func success(job: JobEventData) async throws { }
     public func error(jobId: String, error: Error) async throws { }
-    public func error(job: JobEventData) async throws { }
+    public func error(job: JobEventData, error: Error) async throws { }
     
     public func dispatched(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.makeFutureWithTask {

--- a/Sources/Queues/NotificationHook.swift
+++ b/Sources/Queues/NotificationHook.swift
@@ -16,6 +16,12 @@ public protocol JobEventDelegate {
     ///   - eventLoop: The eventLoop
     func didDequeue(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
+    /// Called when the job is dequeued
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    ///   - eventLoop: The eventLoop
+    func didDequeue(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void>
+
 
     /// Called when the job succeeds
     /// - Parameters:
@@ -23,12 +29,26 @@ public protocol JobEventDelegate {
     ///   - eventLoop: The eventLoop
     func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void>
 
+    /// Called when the job succeeds
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    ///   - eventLoop: The eventLoop
+    func success(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void>
+
+    
     /// Called when the job returns an error
     /// - Parameters:
     ///   - jobId: The id of the Job
     ///   - error: The error that caused the job to fail
     ///   - eventLoop: The eventLoop
     func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
+    
+    /// Called when the job returns an error
+    /// - Parameters:
+    ///   - job: The `JobData` associated with the job
+    ///   - error: The error that caused the job to fail
+    ///   - eventLoop: The eventLoop
+    func error(job: JobEventData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void>
 }
 
 extension JobEventDelegate {
@@ -40,11 +60,23 @@ extension JobEventDelegate {
         eventLoop.future()
     }
 
+    public func didDequeue(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.future()
+    }
+
     public func success(jobId: String, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 
+    public func success(job: JobEventData, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.future()
+    }
+
     public func error(jobId: String, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
+        eventLoop.future()
+    }
+    
+    public func error(job: JobEventData, error: Error, eventLoop: EventLoop) -> EventLoopFuture<Void> {
         eventLoop.future()
     }
 }


### PR DESCRIPTION
Add optional `didDequeue`, `success` and `error` notification hook methods (delegate) and their async versions, to pass the `JobEventData` to the delegate

Changes:
Notification hooks send only `jobId` as a parameter, except for `dispatch` method, which sends `JobEventData`. This PR will add 3 more hook methods for `didDequeue`, `success` and `error` which pass `JobEventData` as a parameter. 
Despite `jobId` is already present in `JobEventData`, previous delegate methods were left unchanged, to prevent code breaking changes.

