### PR TITLE
Adopt Async Lifecycle Handler

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,4 +8,4 @@ jobs:
      uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
      with:
        with_coverage: true
-       with_tsan: true
+       with_tsan: false

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.8
 import PackageDescription
 
 let package = Package(
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "XCTQueues", targets: ["XCTQueues"])
     ],
     dependencies: [
-        .package(url: "https://github.com/vapor/vapor.git", from: "4.76.2"),
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.101.1"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
     ],
     targets: [

--- a/Sources/Queues/Application+Queues.swift
+++ b/Sources/Queues/Application+Queues.swift
@@ -49,6 +49,13 @@ extension Application {
                     driver.shutdown()
                 }
             }
+            
+            func shutdownAsync(_ application: Application) async {
+                application.queues.storage.commands.forEach({$0.shutdown()})
+                if let driver = application.queues.storage.driver {
+                    await driver.asyncShutdown()
+                }
+            }
         }
 
         /// The `QueuesConfiguration` object

--- a/Sources/Queues/Application+Queues.swift
+++ b/Sources/Queues/Application+Queues.swift
@@ -51,7 +51,9 @@ extension Application {
             }
             
             func shutdownAsync(_ application: Application) async {
-                application.queues.storage.commands.forEach({$0.shutdown()})
+                for command in application.queues.storage.commands {
+                    await command.asyncShutdown()
+                }
                 if let driver = application.queues.storage.driver {
                     await driver.asyncShutdown()
                 }

--- a/Sources/Queues/QueuesDriver.swift
+++ b/Sources/Queues/QueuesDriver.swift
@@ -6,4 +6,13 @@ public protocol QueuesDriver {
     
     /// Shuts down the driver
     func shutdown()
+    
+    /// Shut down the driver asyncrhonously. Helps avoid calling `.wait()`
+    func asyncShutdown() async
+}
+
+extension QueuesDriver {
+    public func asyncShutdown() async {
+        shutdown()
+    }
 }

--- a/Sources/Queues/RepeatedTask+Cancel.swift
+++ b/Sources/Queues/RepeatedTask+Cancel.swift
@@ -10,4 +10,14 @@ extension RepeatedTask {
             print("failed cancelling repeated task \(error)")
         }
     }
+    
+    func asyncCancel(on eventLoop: EventLoop) async {
+        do {
+            let promise = eventLoop.makePromise(of: Void.self)
+            self.cancel(promise: promise)
+            try await promise.futureResult.get()
+        } catch {
+            print("failed cancelling repeated task \(error)")
+        }
+    }
 }


### PR DESCRIPTION
Adopt Vapor's asynchronous `LifecycleHandler` APIs to avoid calling `.wait()` in the main application flow