### PR TITLE
Run until no more work is pending

### DIFF
--- a/Tests/QueuesTests/AsyncQueueTests.swift
+++ b/Tests/QueuesTests/AsyncQueueTests.swift
@@ -37,6 +37,8 @@ final class AsyncQueueTests: XCTestCase {
         
         app.get("foo") { req in
             try await req.queue.dispatch(MyAsyncJob.self, .init(foo: "bar"))
+            try await req.queue.dispatch(MyAsyncJob.self, .init(foo: "baz"))
+            try await req.queue.dispatch(MyAsyncJob.self, .init(foo: "quux"))
             return "done"
         }
         
@@ -45,8 +47,8 @@ final class AsyncQueueTests: XCTestCase {
             XCTAssertEqual(res.body.string, "done")
         }
         
-        XCTAssertEqual(app.queues.test.queue.count, 1)
-        XCTAssertEqual(app.queues.test.jobs.count, 1)
+        XCTAssertEqual(app.queues.test.queue.count, 3)
+        XCTAssertEqual(app.queues.test.jobs.count, 3)
         let job = app.queues.test.first(MyAsyncJob.self)
         XCTAssert(app.queues.test.contains(MyAsyncJob.self))
         XCTAssertNotNil(job)
@@ -67,6 +69,8 @@ final class AsyncQueueTests: XCTestCase {
         
         app.get("foo") { req in
             try await req.queue.dispatch(MyAsyncJob.self, .init(foo: "bar"))
+            try await req.queue.dispatch(MyAsyncJob.self, .init(foo: "baz"))
+            try await req.queue.dispatch(MyAsyncJob.self, .init(foo: "quux"))
             return "done"
         }
         
@@ -75,8 +79,8 @@ final class AsyncQueueTests: XCTestCase {
             XCTAssertEqual(res.body.string, "done")
         }
         
-        XCTAssertEqual(app.queues.asyncTest.queue.count, 1)
-        XCTAssertEqual(app.queues.asyncTest.jobs.count, 1)
+        XCTAssertEqual(app.queues.asyncTest.queue.count, 3)
+        XCTAssertEqual(app.queues.asyncTest.jobs.count, 3)
         let job = app.queues.asyncTest.first(MyAsyncJob.self)
         XCTAssert(app.queues.asyncTest.contains(MyAsyncJob.self))
         XCTAssertNotNil(job)


### PR DESCRIPTION
First pass at fixing #124.

Currently, every refresh interval, workers run a single task. This means that the maximum task throughput in the refresh interval is the number of workers.

With this change, every refresh interval, workers run tasks until there are no more tasks. This means that task throughput is tied to the speed of processing tasks, rather than just the number of workers.

Open to feedback about the approach, and I haven't added any tests here yet. This is a fairly major behavioural change, but should result in a large speed increase for most users.