### PR TITLE
Fix usage of the Metrics Timer.

### DIFF
--- a/Tests/QueuesTests/MetricsTests.swift
+++ b/Tests/QueuesTests/MetricsTests.swift
@@ -39,11 +39,11 @@ final class MetricsTests: XCTestCase {
 
         try await self.app.queues.queue.worker.run()
 
-        let timer = try XCTUnwrap(self.metrics.timers.first(where: { $0.label == "some-id.jobDurationTimer" }))
+        let timer = try XCTUnwrap(self.metrics.timers.first(where: { $0.label == "MyAsyncJob.jobDurationTimer" }))
         let successDimension = try XCTUnwrap(timer.dimensions.first(where: { $0.0 == "success" }))
-        let idDimension = try XCTUnwrap(timer.dimensions.first(where: { $0.0 == "id" }))
+        let idDimension = try XCTUnwrap(timer.dimensions.first(where: { $0.0 == "jobName" }))
         XCTAssertEqual(successDimension.1, "true")
-        XCTAssertEqual(idDimension.1, "some-id")
+        XCTAssertEqual(idDimension.1, "MyAsyncJob")
 
         try XCTAssertNoThrow(promise.futureResult.wait())
     }


### PR DESCRIPTION
**These changes are now available in [1.16.1](https://github.com/vapor/queues/releases/tag/1.16.1)**


When using the `Timer` aggregate the measurements by status and job name rather than by status and job id.

Job id is unique to each job run and therefore in the current implementation a new summary is created for each job run which doesn't collect useful metrics data and causes excessive memory usage.