### PR TITLE
Fix typo in QueuesCommand code comments

### DIFF
--- a/Sources/Queues/QueuesCommand.swift
+++ b/Sources/Queues/QueuesCommand.swift
@@ -180,7 +180,7 @@ public final class QueuesCommand: AsyncCommand, Sendable {
         self.box.withLockedValue { box in
             box.didShutdown = true
         
-            // stop running in case shutting downf rom signal
+            // stop running in case shutting down from signal
             self.application.running?.stop()
         
             // clear signal sources
@@ -202,7 +202,7 @@ public final class QueuesCommand: AsyncCommand, Sendable {
         let (jobTasks, scheduledTasks) = self.box.withLockedValue { box in
             box.didShutdown = true
         
-            // stop running in case shutting downf rom signal
+            // stop running in case shutting down from signal
             self.application.running?.stop()
             
             // clear signal sources


### PR DESCRIPTION
Noticed a tiny typo when looking at the code.