### PR TITLE
Add Meter for in-progress jobs

### DIFF
--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -65,10 +65,10 @@ public struct QueueWorker: Sendable {
             try await $0.didDequeue(jobId: id.string, eventLoop: self.queue.eventLoop).get()
         }
 
-        Gauge(
-            label: "jobs.in.progress.gauge", 
+        Meter(
+            label: "jobs.in.progress.meter", 
             dimensions: [("queueName", self.queue.queueName.string)]
-        ).record(1)
+        ).increment()
 
         try await self.runOneJob(id: id, job: job, jobData: data, logger: logger)
         return true
@@ -148,9 +148,9 @@ public struct QueueWorker: Sendable {
             ).increment()
         }
 
-        Gauge(
-            label: "jobs.in.progress.gauge",
+        Meter(
+            label: "jobs.in.progress.meter",
             dimensions: [("queueName", queue.queueName.string)]
-        ).record(-1)
+        ).decrement()
     }
 }

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -128,7 +128,7 @@ public struct QueueWorker: Sendable {
         error: (any Error)? = nil
     ) {
         Timer(
-            label: "\(jobName).duration.timer",
+            label: "\(jobName).jobDurationTimer",
             dimensions: [
                 ("success", error == nil ? "true" : "false"),
                 ("jobName", jobName),

--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -13,7 +13,7 @@ extension Queue {
 /// The worker that runs ``Job``s.
 public struct QueueWorker: Sendable {
     let queue: any Queue
-    
+
     /// Run the queue until there is no more work to be done.
     /// This is a thin wrapper for ELF-style callers.
     public func run() -> EventLoopFuture<Void> {

--- a/Tests/QueuesTests/MetricsTests.swift
+++ b/Tests/QueuesTests/MetricsTests.swift
@@ -39,7 +39,7 @@ final class MetricsTests: XCTestCase {
 
         try await self.app.queues.queue.worker.run()
 
-        let timer = try XCTUnwrap(self.metrics.timers.first(where: { $0.label == "MyAsyncJob.duration.timer" }))
+        let timer = try XCTUnwrap(self.metrics.timers.first(where: { $0.label == "MyAsyncJob.jobDurationTimer" }))
         let successDimension = try XCTUnwrap(timer.dimensions.first(where: { $0.0 == "success" }))
         let idDimension = try XCTUnwrap(timer.dimensions.first(where: { $0.0 == "jobName" }))
         XCTAssertEqual(successDimension.1, "true")

--- a/Tests/QueuesTests/MetricsTests.swift
+++ b/Tests/QueuesTests/MetricsTests.swift
@@ -39,7 +39,7 @@ final class MetricsTests: XCTestCase {
 
         try await self.app.queues.queue.worker.run()
 
-        let timer = try XCTUnwrap(self.metrics.timers.first(where: { $0.label == "MyAsyncJob.jobDurationTimer" }))
+        let timer = try XCTUnwrap(self.metrics.timers.first(where: { $0.label == "MyAsyncJob.duration.timer" }))
         let successDimension = try XCTUnwrap(timer.dimensions.first(where: { $0.0 == "success" }))
         let idDimension = try XCTUnwrap(timer.dimensions.first(where: { $0.0 == "jobName" }))
         XCTAssertEqual(successDimension.1, "true")
@@ -66,6 +66,7 @@ final class MetricsTests: XCTestCase {
         let counter = try XCTUnwrap(self.metrics.counters.first(where: { $0.label == "success.completed.jobs.counter" }))
         let queueNameDimension = try XCTUnwrap(counter.dimensions.first(where: { $0.0 == "queueName" }))
         XCTAssertEqual(queueNameDimension.1, self.app.queues.queue.queueName.string)
+        XCTAssertEqual(counter.lastValue, 1)
     }
 
     func testErroringJobsCounter() async throws {
@@ -86,6 +87,7 @@ final class MetricsTests: XCTestCase {
         let counter = try XCTUnwrap(self.metrics.counters.first(where: { $0.label == "error.completed.jobs.counter" }))
         let queueNameDimension = try XCTUnwrap(counter.dimensions.first(where: { $0.0 == "queueName" }))
         XCTAssertEqual(queueNameDimension.1, self.app.queues.queue.queueName.string)
+        XCTAssertEqual(counter.lastValue, 1)
     }
 
     func testDispatchedJobsCounter() async throws {
@@ -110,5 +112,28 @@ final class MetricsTests: XCTestCase {
         let jobNameDimension = try XCTUnwrap(counter.dimensions.first(where: { $0.0 == "jobName" }))
         XCTAssertEqual(queueNameDimension.1, self.app.queues.queue.queueName.string)
         XCTAssertEqual(jobNameDimension.1, MyAsyncJob.name)
+        XCTAssertEqual(counter.totalValue, 2)
+    }
+
+    func testInProgressJobsGauge() async throws {
+        let promise = self.app.eventLoopGroup.next().makePromise(of: Void.self)
+        self.app.queues.add(MyAsyncJob(promise: promise))
+
+        self.app.get("foo") { req async throws in
+            try await req.queue.dispatch(MyAsyncJob.self, .init(foo: "bar"))
+            return "done"
+        }
+
+        try await self.app.testable().test(.GET, "foo") { res async in
+            XCTAssertEqual(res.status, .ok)
+            XCTAssertEqual(res.body.string, "done")
+        }
+
+        try await self.app.queues.queue.worker.run()
+
+        let meter = try XCTUnwrap(self.metrics.meters.first(where: { $0.label == "jobs.in.progress.meter" }))
+        let queueNameDimension = try XCTUnwrap(meter.dimensions.first(where: { $0.0 == "queueName" }))
+        XCTAssertEqual(queueNameDimension.1, self.app.queues.queue.queueName.string)
+        XCTAssertEqual(meter.values, [1, 0])
     }
 }


### PR DESCRIPTION
This adds a `Meter` metric to record the number of jobs currently being processed by a worker. 
The gauge also allows calculation of not yet processed but enqueued jobs, since we can now do
```
notYetProcessedJobs = dispatchedJobsCount - (errorCompleted + successCompleted) - inProgressJobs
```
