### PR TITLE
Don’t set `delayUntil` if there is no delay

### DIFF
--- a/Sources/Queues/QueueWorker.swift
+++ b/Sources/Queues/QueueWorker.swift
@@ -108,7 +108,7 @@ public struct QueueWorker: Sendable {
             payload: jobData.payload,
             maxRetryCount: jobData.maxRetryCount,
             jobName: jobData.jobName,
-            delayUntil: .init(timeIntervalSinceNow: Double(delay)),
+            delayUntil: delay == 0 ? nil : .init(timeIntervalSinceNow: Double(delay)),
             queuedAt: .init(),
             attempts: jobData.currentAttempt
         )


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Currently, if a job is retried with no delay, the `delayUntil` property is set to the current time. I noticed this since it was causing some issues with a new test in https://github.com/vapor-community/vapor-queues-fluent-driver/pull/15. This PR adjusts this so that `delayUntil` is `nil` when there is no retry delay. This aligns the behaviour with how new jobs with no delay are created.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
